### PR TITLE
Unpublish package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,3 +26,4 @@ jobs:
     - run: npm unpublish "@${{ github.repository }}@1.0.0-g${{ github.sha }}"
       env:
         NODE_AUTH_TOKEN: ${{ secrets.PUBLISH_PACKAGES }}
+


### PR DESCRIPTION
This doesn't work:

```
npm ERR! 405 Method Not Allowed - PUT https://npm.pkg.github.com/@jcansdale-test%2fregistry-package-event/-rev/undefined - Package deletion from the command line is disabled in GitHub Package Registry. For further details please visit https://help.github.com/en/packages/publishing-and-managing-packages/deleting-a-package.
```